### PR TITLE
Add "Event handler naming" to Code Quality

### DIFF
--- a/codeQuality/index.md
+++ b/codeQuality/index.md
@@ -105,6 +105,16 @@ When destructuring an object that may be undefined, employ the following syntax:
 const { nativeToken } = colony || {};
 ```
 
+### Event handler naming
+
+To make it easier to distinguish between "internal" and "external" event handlers, use the `on` prefix for naming props and `handle` for naming functions, e.g.:
+
+```jsx
+const handleClick = () => {};
+
+<Button onClick={handleClick} />
+```
+
 ## Javascript best practices
 
 ### Explicitly scoping `if` statements


### PR DESCRIPTION
A little convention that I find helpful and is pretty much standard in the ecosystem 

https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md https://jaketrent.com/post/naming-event-handlers-react/